### PR TITLE
Move `ModeChange` hooks to `window` scope

### DIFF
--- a/rc/number-toggle.kak
+++ b/rc/number-toggle.kak
@@ -28,20 +28,20 @@ hook -always global WinCreate .* %{
   set-option window number_toggle_internal_state '-relative'
   number-toggle-refresh
   number-toggle-install-focus-hooks
-}
 
-# Display absolute line numbers when entering insert mode
-hook -always global ModeChange push:.*:insert %{
-  set-option window number_toggle_internal_state ''
-  number-toggle-refresh
-  number-toggle-uninstall-focus-hooks
-}
+  # Display absolute line numbers when entering insert mode
+  hook -always window ModeChange push:.*:insert %{
+    set-option window number_toggle_internal_state ''
+    number-toggle-refresh
+    number-toggle-uninstall-focus-hooks
+  }
 
-# Display relative line numbers when leaving insert mode
-hook -always global ModeChange pop:insert:.* %{
-  set-option window number_toggle_internal_state '-relative'
-  number-toggle-refresh
-  number-toggle-install-focus-hooks
+  # Display relative line numbers when leaving insert mode
+  hook -always window ModeChange pop:insert:.* %{
+    set-option window number_toggle_internal_state '-relative'
+    number-toggle-refresh
+    number-toggle-install-focus-hooks
+  }
 }
 
 }


### PR DESCRIPTION
Whenever the idle hook runs (every 50ms after typing by default),
the following would get logged to the console:
```
error running hook ModeChange(push:normal:insert)/: 2:3: 'set-option': no window in context
error running hook ModeChange(pop:insert:normal)/: 2:3: 'set-option': no window in context
```
This change switches to a window hook instead of a global hook
to prevent these messages.